### PR TITLE
Fix bug that field value is struct

### DIFF
--- a/core/hc_http_client.go
+++ b/core/hc_http_client.go
@@ -149,7 +149,8 @@ func (hc *HcHttpClient) GetFieldValueByName(name string, jsonTag map[string]stri
 			}
 			return reflect.ValueOf(nil), errors.New("request field " + name + " read null value")
 		}
-		return value.Elem(), nil
+		// For field value is struct
+		value = value.Elem()
 	}
 
 	if value.Kind() == reflect.Struct {


### PR DESCRIPTION
In current implementation, request type with struct ptr isn't handled properly. Code to reproduce this bug as below:

```go
	visibilityEnum := imsModel.GetListImagesRequestVisibilityEnum()
	statusEnum := imsModel.GetListImagesRequestStatusEnum()
	req := &imsModel.ListImagesRequest{
		Visibility: &visibilityEnum.PRIVATE,
		Status: &statusEnum.ACTIVE,
	}
       resp, err := client.ListImages(req)
       // generated URL is like:  ?status={active}&visibility={private}

```