### PR TITLE
Fix proxy url

### DIFF
--- a/core/config/http_config.go
+++ b/core/config/http_config.go
@@ -21,8 +21,9 @@ package config
 
 import (
 	"fmt"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/httphandler"
 	"time"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/httphandler"
 )
 
 const DefaultTimeout = 120 * time.Second
@@ -111,6 +112,8 @@ func (p *Proxy) GetProxyUrl() string {
 	var proxyUrl string
 	if p.Username != "" {
 		proxyUrl = fmt.Sprintf("%s://%s:%s@%s", p.Schema, p.Username, p.Password, p.Host)
+	} else {
+		proxyUrl = fmt.Sprintf("%s://%s", p.Schema, p.Host)
 	}
 	if p.Port != 0 {
 		proxyUrl = fmt.Sprintf("%s:%d", proxyUrl, p.Port)


### PR DESCRIPTION
Related to issue https://github.com/huaweicloud/huaweicloud-sdk-go-v3/issues/14
The GetProxyUrl function should return proper url when username and
password are not set.